### PR TITLE
Fix lingering PlatformChannel Method Call

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -36,8 +36,13 @@ android {
     }
 }
 
+repositories {
+    maven { url 'https://artifacts.netcore.co.in/artifactory/android' }
+}
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.netcore.android:smartech-sdk:3.1.4'
-    implementation 'androidx.work:work-runtime-ktx:2.5.0'
+
+    implementation 'com.netcore.android:smartech-sdk:3.1.22'
+    implementation 'androidx.work:work-runtime-ktx:2.7.1'
 }

--- a/android/src/main/kotlin/com/smartech/flutter/smartech_plugin/SmartechPlugin.kt
+++ b/android/src/main/kotlin/com/smartech/flutter/smartech_plugin/SmartechPlugin.kt
@@ -94,7 +94,6 @@ class SmartechPlugin: FlutterPlugin, MethodCallHandler,ActivityAware,Application
     when (call.method) {
       "getPlatformVersion" -> {
         result.success("Android ${android.os.Build.VERSION.RELEASE}")
-
       }
 
       "setDevicePushToken" -> {
@@ -111,20 +110,22 @@ class SmartechPlugin: FlutterPlugin, MethodCallHandler,ActivityAware,Application
       "setDebugLevel" -> {
         if (call.arguments is Int) {
           setDebugLevel(call.arguments as Int)
+          result.success(null)
         } else {
           result.error("", "level should be in int", null)
         }
       }
       "trackAppInstall" -> {
         trackAppInstall()
+        result.success(null)
       }
       "trackAppUpdate" -> {
         trackAppUpdate()
+        result.success(null)
       }
       "trackAppInstallUpdateBySmartech" -> {
-
         trackAppInstallUpdateBySmartech()
-
+        result.success(null)
       }
       "setInAppCustomHTMLListener" -> {
         setInAppCustomHTMLListener()
@@ -134,43 +135,56 @@ class SmartechPlugin: FlutterPlugin, MethodCallHandler,ActivityAware,Application
             channel.invokeMethod("setInAppCustomHTMLListener", it)
           })
         }
+
+        result.success(null)
       }
       "handlePushNotification" -> {
         handlePushNotification(call.arguments as String)
+        result.success(null)
       }
       "createNotificationChannel" -> {
         createNotificationChannel(call.arguments as HashMap<String, Any>)
+        result.success(null)
       }
       "createNotificationChannelGroup" -> {
         createNotificationChannelGroup(call.arguments as HashMap<String, Any>)
+        result.success(null)
       }
       "deleteNotificationChannel" -> {
         deleteNotificationChannel(call.arguments as String)
+        result.success(null)
       }
       "deleteNotificationChannelGroup" -> {
         deleteNotificationChannelGroup(call.arguments as String)
+        result.success(null)
       }
       "updateUserProfile" -> {
         updateUserProfile(call.arguments as HashMap<String, Any>)
+        result.success(null)
       }
       "setUserIdentity" -> {
         setUserIdentity(call.arguments as String)
+        result.success(null)
       }
       "login" -> {
         login(call.arguments as String)
-        channel.invokeMethod("caca", "asa")
+        result.success(null)
       }
       "clearUserIdentity" -> {
         smartech.clearUserIdentity()
+        result.success(null)
       }
       "logoutAndClearUserIdentity" -> {
         smartech.logoutAndClearUserIdentity(call.arguments as Boolean)
+        result.success(null)
       }
       "trackEvent" -> {
         trackEvent(call.arguments as HashMap<String, Any>)
+        result.success(null)
       }
       "setNotificationOptions" -> {
         setNotificationOptions(call.arguments as HashMap<String, Any>)
+        result.success(null)
       }
       "getDeviceUniqueId" -> {
         val guid = smartech.getDeviceUniqueId()
@@ -178,29 +192,32 @@ class SmartechPlugin: FlutterPlugin, MethodCallHandler,ActivityAware,Application
       }
       "setUserLocation" -> {
         setUserLocation(call.arguments as HashMap<String, Any>)
+        result.success(null)
       }
       "optTracking" -> {
         smartech.optTracking(call.arguments as Boolean)
+        result.success(null)
       }
       "hasOptedTracking" -> {
         result.success(smartech.hasOptedTracking())
       }
       "optPushNotification" -> {
         smartech.optPushNotification(call.arguments as Boolean)
+        result.success(null)
       }
       "hasOptedPushNotification" -> {
         result.success(smartech.hasOptedPushNotification())
       }
       "optInAppMessage" -> {
         smartech.optInAppMessage(call.arguments as Boolean)
-
+        result.success(null)
       }
       "hasOptedInAppMessage" -> {
         result.success(smartech.hasOptedInAppMessage())
       }
       "processEventsManually" -> {
         smartech.processEventsManually()
-
+        result.success(null)
       }
       "getUserIdentity" -> {
         result.success(smartech.getUserIdentity())
@@ -213,6 +230,7 @@ class SmartechPlugin: FlutterPlugin, MethodCallHandler,ActivityAware,Application
       }
       "openNativeWebView" -> {
         openNativeWebView?.invoke()
+        result.success(null)
       }
       "onhandleDeeplinkAction" -> {
         DeeplinkReceivers.deeplinkReceiverCallBack = { deepLinkUrl, payload ->
@@ -249,12 +267,9 @@ class SmartechPlugin: FlutterPlugin, MethodCallHandler,ActivityAware,Application
                 }
               })
             })
-
-
           }
-
-
         }
+        result.success(null)
       }
       "onhandleDeeplinkActionBackground" -> {
         val deeplinkUrl = context.getSharedPreferences("Deeplink_action", Context.MODE_PRIVATE).getString("deepLinkUrl", null)
@@ -288,13 +303,15 @@ class SmartechPlugin: FlutterPlugin, MethodCallHandler,ActivityAware,Application
             })
           })
         }
+        result.success(null)
       }
       "openUrl" -> {
         openUrl?.invoke(call.arguments as String)
+        result.success(null)
       }
 
       else -> {
-        result.success("Android ${android.os.Build.VERSION.RELEASE}")
+        result.notImplemented()
       }
     }
 

--- a/ios/Classes/SwiftSmartechPlugin.swift
+++ b/ios/Classes/SwiftSmartechPlugin.swift
@@ -2,7 +2,7 @@ import Flutter
 import UIKit
 import Smartech
 protocol SwiftSmartechPluginDelegate:class {
-    
+
 }
 public class SwiftSmartechPlugin: NSObject, FlutterPlugin {
     public static let sharedInstance = SwiftSmartechPlugin()
@@ -12,7 +12,7 @@ public class SwiftSmartechPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
      channel = FlutterMethodChannel(name: "smartech_plugin", binaryMessenger: registrar.messenger())
     let instance = SwiftSmartechPlugin()
-    
+
     registrar.addMethodCallDelegate(instance, channel: channel!)
   }
    public static func handleDeeplinkAction(withURLString deeplinkURLString: String, andCustomPayload customPayload: [AnyHashable : Any]?) {
@@ -21,7 +21,7 @@ public class SwiftSmartechPlugin: NSObject, FlutterPlugin {
             "customPayload":customPayload ?? [:],
             "isAfterTerminated":false
         ] as [String : Any]
-   
+
     channel?.invokeMethod("onhandleDeeplinkAction", arguments: dict, result: { (value) in
         let userDefault = UserDefaults.standard
         guard let value = value else {
@@ -44,39 +44,52 @@ public class SwiftSmartechPlugin: NSObject, FlutterPlugin {
         result(Smartech.sharedInstance().getDevicePushToken())
     case "getDeviceGuid":
         result(Smartech.sharedInstance().getDeviceGuid())
-        
+
     case "updateUserProfile" :
         Smartech.sharedInstance().updateUserProfile(call.arguments as! Dictionary<AnyHashable, Any>)
-        
+        result(nil)
     case "setUserIdentity":
         Smartech.sharedInstance().setUserIdentity(call.arguments as! String)
+        result(nil)
     case "getUserIdentity":
         result(Smartech.sharedInstance().getUserIdentity())
-        
+
     case "login":
         Smartech.sharedInstance().login(call.arguments as! String)
+        result(nil)
     case "clearUserIdentity":
         Smartech.sharedInstance().clearUserIdentity()
+        result(nil)
     case "logoutAndClearUserIdentity":
         Smartech.sharedInstance().logoutAndClearUserIdentity(call.arguments as! Bool)
+        result(nil)
     case "trackAppInstallUpdateBySmartech":
         Smartech.sharedInstance().trackAppInstallUpdateBySmartech()
+        result(nil)
     case "trackAppInstall":
         Smartech.sharedInstance().trackAppInstall()
+        result(nil)
     case "trackAppUpdate":
         Smartech.sharedInstance().trackAppUpdate()
+        result(nil)
     case "trackEvent":
         trackEvent(call: call)
+        result(nil)
     case "setUserLocation":
         setUserLocation(call: call)
+        result(nil)
     case "processEventsManually":
         Smartech.sharedInstance().processEventsManually()
+        result(nil)
     case "optTracking":
         Smartech.sharedInstance().optTracking(call.arguments as! Bool)
+        result(nil)
     case "optInAppMessage":
-    Smartech.sharedInstance().opt(inAppMessage: call.arguments as! Bool)
+        Smartech.sharedInstance().opt(inAppMessage: call.arguments as! Bool)
+        result(nil)
     case "optPushNotification":
         Smartech.sharedInstance().optPushNotification(call.arguments as! Bool)
+        result(nil)
     case "hasOptedTracking":
         result(Smartech.sharedInstance().hasOptedTracking())
     case "hasOptedPushNotification":
@@ -87,6 +100,7 @@ public class SwiftSmartechPlugin: NSObject, FlutterPlugin {
         result(Smartech.sharedInstance().getDeviceGuid())
     case "openNativeWebView":
         SwiftSmartechPlugin.openNativeWebView?()
+        result(nil)
     case "onhandleDeeplinkActionBackground":
         let userDefault = UserDefaults.standard
         guard let dict = userDefault.dictionary(forKey: "DeeplinkActionData") else {
@@ -96,24 +110,24 @@ public class SwiftSmartechPlugin: NSObject, FlutterPlugin {
         dictionary["isAfterTerminated"] = true
         SwiftSmartechPlugin.channel?.invokeMethod("onhandleDeeplinkAction", arguments: dict)
         userDefault.removeObject(forKey: "DeeplinkActionData")
+        result(nil)
     default:
-        
-        print("Not Implemant")
+        result(FlutterMethodNotImplemented)
     }
-   
+
   }
-    
+
     private func setUserLocation(call: FlutterMethodCall) {
         let dict = call.arguments as! Dictionary<String, Any>
         let location = CLLocationCoordinate2DMake(dict["latitude"] as! Double, dict["longitude"] as! Double)
         Smartech.sharedInstance().setUserLocation(location)
 
     }
-    
+
     private func trackEvent(call: FlutterMethodCall) {
         let dict = call.arguments as! Dictionary<String, Any>
         Smartech.sharedInstance().trackEvent(dict["event_name"] as! String, andPayload: dict["event_data"] as? Dictionary<AnyHashable, Any>)
     }
 
-   
+
 }


### PR DESCRIPTION
Using PlatformChannel without calling `result.success(null)` results in [lingering result handler](https://api.flutter.dev/javadoc/io/flutter/plugin/common/MethodChannel.MethodCallHandler.html).